### PR TITLE
chore(deps): update Python test dependencies together

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-pytest==8.3.4
-pytest-asyncio==0.24.0
+pytest==9.1.1
+pytest-asyncio==1.4.0


### PR DESCRIPTION
Updates pytest to 9.1.1 and pytest-asyncio to 1.4.0 together because either update alone has an incompatible dependency constraint. Local verification: 14 backend tests passed, compileall passed, and pip-audit found no known vulnerabilities. Supersedes #6 and #8.