### PR TITLE
Release v1.3.0 with reliable Auto-Sync rescheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to Immich Family Tools are documented here.
 
+## [1.3.0] – 2026-08-02
+
+### Immich v3 compatibility
+- Added tested compatibility with Immich v3.1
+- Migrated person asset discovery to the paginated `POST /api/search/metadata` API
+- Updated people pagination to use Immich v3's `size` parameter
+- Updated Name Sync to modify people through `PATCH`
+- Deduplicated paginated asset IDs and prevented assets already present in an album from being added again
+
+### Auto-Sync reliability
+- Auto-Sync now records the executed date and configured time as one slot
+- Changing the configured time allows one intentional additional run on the same day
+- An unchanged time slot remains protected against duplicate runs during the polling window
+
+### Maintenance and verification
+- Updated tested backend, frontend and GitHub Actions dependencies
+- Added regression coverage for Immich v3 album search, people pagination, Name Sync and scheduled synchronization
+- Verified manual and automatic album synchronization against Immich v3.1 in production
+- Backend tests, frontend tests, typecheck, production build, audits, secret scan and container build pass
+
+### Upgrade notes
+- No persisted-data migration is required
+- Existing `.env`, accounts, managed albums and sync history remain compatible
+- Rebuild the container from this release so the backend and frontend both report version `1.3.0`
+
 ## [1.2.1] – 2026-06-21
 
 ### Maintenance

--- a/backend/main.py
+++ b/backend/main.py
@@ -93,8 +93,8 @@ async def _run_auto_sync(app_state) -> None:
 
 async def _auto_sync_loop(app_state) -> None:
     """Check every 30 s if it is time to run the nightly auto-sync.
-    Fires exactly once per day at the configured local time."""
-    last_run_date = None
+    Fires exactly once per configured local-time slot."""
+    last_run_slot = None
     while True:
         await asyncio.sleep(30)
         try:
@@ -103,8 +103,9 @@ async def _auto_sync_loop(app_state) -> None:
                 continue
             now = datetime.now()
             h, m = map(int, cfg.get("time", "01:00").split(":"))
-            if now.hour == h and now.minute == m and now.date() != last_run_date:
-                last_run_date = now.date()
+            current_slot = (now.date(), h, m)
+            if now.hour == h and now.minute == m and current_slot != last_run_slot:
+                last_run_slot = current_slot
                 logger.info("Auto-sync triggered at %02d:%02d", h, m)
                 await _run_auto_sync(app_state)
         except Exception as exc:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,3 +1,5 @@
+import asyncio
+from datetime import datetime as RealDateTime
 from types import SimpleNamespace
 
 import pytest
@@ -41,3 +43,74 @@ async def test_scheduled_sync_refreshes_each_managed_album(monkeypatch):
     await main._run_auto_sync(SimpleNamespace(store=Store()))
 
     assert refreshed == ["managed-1"]
+
+
+@pytest.mark.asyncio
+async def test_auto_sync_runs_again_when_rescheduled_for_later_the_same_day(monkeypatch):
+    configured_times = iter(("12:01", "12:03"))
+    current_times = iter((
+        RealDateTime(2026, 8, 2, 12, 1),
+        RealDateTime(2026, 8, 2, 12, 3),
+    ))
+    runs: list[str] = []
+    sleep_calls = 0
+
+    class Store:
+        def get_auto_sync_config(self):
+            return {"enabled": True, "time": next(configured_times)}
+
+    class FakeDateTime:
+        @classmethod
+        def now(cls):
+            return next(current_times)
+
+    async def fake_sleep(_seconds):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls > 2:
+            raise asyncio.CancelledError
+
+    async def run_auto_sync(_state):
+        runs.append("run")
+
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "datetime", FakeDateTime)
+    monkeypatch.setattr(main, "_run_auto_sync", run_auto_sync)
+
+    with pytest.raises(asyncio.CancelledError):
+        await main._auto_sync_loop(SimpleNamespace(store=Store()))
+
+    assert runs == ["run", "run"]
+
+
+@pytest.mark.asyncio
+async def test_auto_sync_runs_only_once_for_the_same_time_slot(monkeypatch):
+    runs: list[str] = []
+    sleep_calls = 0
+
+    class Store:
+        def get_auto_sync_config(self):
+            return {"enabled": True, "time": "12:01"}
+
+    class FakeDateTime:
+        @classmethod
+        def now(cls):
+            return RealDateTime(2026, 8, 2, 12, 1)
+
+    async def fake_sleep(_seconds):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls > 2:
+            raise asyncio.CancelledError
+
+    async def run_auto_sync(_state):
+        runs.append("run")
+
+    monkeypatch.setattr(main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(main, "datetime", FakeDateTime)
+    monkeypatch.setattr(main, "_run_auto_sync", run_auto_sync)
+
+    with pytest.raises(asyncio.CancelledError):
+        await main._auto_sync_loop(SimpleNamespace(store=Store()))
+
+    assert runs == ["run"]

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,1 +1,1 @@
-APP_VERSION = "1.2.1"
+APP_VERSION = "1.3.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "immich-family-tools",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "immich-family-tools",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.4",
         "lucide-react": "^1.27.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "immich-family-tools",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "1.2.1";
+export const APP_VERSION = "1.3.0";


### PR DESCRIPTION
## Summary
- allow Auto-Sync to run once for each explicitly configured time slot on the same day
- retain duplicate protection for an unchanged time slot
- add deterministic scheduler regression coverage
- set backend and frontend version to 1.3.0
- document Immich v3 compatibility, scheduler behavior, verification, and upgrade notes

## Validation
- backend: 25 tests passed
- frontend: tests, typecheck, and production build passed
- npm audit: 0 vulnerabilities
- manual and automatic album sync verified against Immich v3.1 in production