### PR TITLE
docs: make project support link visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Built with Claude Code](https://img.shields.io/badge/Built%20with-Claude%20Code-orange?logo=anthropic)](https://claude.ai/claude-code)
 [![Vibe Coded](https://img.shields.io/badge/Vibe%20Coded-100%25-blueviolet)](https://claude.ai)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy_me_a_coffee-support-FFDD00?logo=buymeacoffee&logoColor=000000)](https://buymeacoffee.com/trust1509)
 
 Solving the missing cross-account face recognition problem via the Immich REST API, without touching your existing Immich installation.
 


### PR DESCRIPTION
## Summary
- place the existing Buy Me a Coffee link alongside the README badges
- keep the detailed Support section unchanged

## Testing
- documentation-only change
- git diff --check passed