### PR TITLE
Allow managed albums to be renamed from the Albums overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This tool bridges that gap.
 - **Match suggestions** — Automatically detects the same person across accounts using name similarity, face embeddings (if available), and shared assets
 - **Name sync** — Set a canonical name across all matched persons with one click; bulk-sync for high-confidence matches
 - **Shared album** — Create a shared album containing all photos of a matched person, populated from each account's own API key
+- **Album rename** — Rename managed albums from the Albums overview; grouped entries are updated in each owning Immich account
 - **Sync log** — Full history of all actions with undo support for name syncs
 
 ### Manual Matching

--- a/backend/models/match.py
+++ b/backend/models/match.py
@@ -83,6 +83,10 @@ class SyncAlbumRequest(BaseModel):
     existing_album_id: Optional[str] = None # for linking existing album
 
 
+class RenameManagedAlbumRequest(BaseModel):
+    album_name: str
+
+
 class SyncLogEntry(BaseModel):
     id: str
     timestamp: str

--- a/backend/routers/albums.py
+++ b/backend/routers/albums.py
@@ -4,7 +4,15 @@ from fastapi import APIRouter, Request
 import errors
 from pydantic import BaseModel
 
-from models.match import SyncNamesRequest, SyncAlbumRequest, SyncLogEntry, ManagedAlbum, SyncNamesMultiRequest, ExtendMatchRequest
+from models.match import (
+    ExtendMatchRequest,
+    ManagedAlbum,
+    RenameManagedAlbumRequest,
+    SyncAlbumRequest,
+    SyncLogEntry,
+    SyncNamesMultiRequest,
+    SyncNamesRequest,
+)
 from services import sync_service
 
 router = APIRouter(prefix="/api/sync", tags=["sync"])
@@ -221,6 +229,30 @@ async def refresh_album(managed_album_id: str, request: Request):
     logs = await sync_service.refresh_managed_album(
         managed=managed, all_accounts=store.list_accounts(), store=store,
     )
+    store.append_log(logs)
+    return logs
+
+
+@router.patch("/albums/{managed_album_id}", response_model=list[SyncLogEntry])
+async def rename_managed_album(
+    managed_album_id: str,
+    body: RenameManagedAlbumRequest,
+    request: Request,
+):
+    new_name = body.album_name.strip()
+    if not new_name:
+        raise errors.album_name_required()
+    store = request.app.state.store
+    managed = next(
+        (album for album in store.get_managed_albums() if album.id == managed_album_id),
+        None,
+    )
+    if not managed:
+        raise errors.managed_album_not_found()
+    owner = store.get_account(managed.owner_account_id)
+    if not owner:
+        raise errors.owner_account_not_found()
+    logs = await sync_service.rename_managed_album(managed, owner, new_name, store)
     store.append_log(logs)
     return logs
 

--- a/backend/services/immich_client.py
+++ b/backend/services/immich_client.py
@@ -190,6 +190,15 @@ class ImmichClient:
             r.raise_for_status()
             return r.json()
 
+    async def update_album(self, album_id: str, payload: dict) -> dict:
+        """Update album metadata such as its name."""
+        async with self._client() as c:
+            r = await c.patch(f"/api/albums/{album_id}", json=payload)
+            if r.status_code == 404:
+                raise AlbumNotFoundError(album_id)
+            r.raise_for_status()
+            return r.json()
+
     async def add_assets_to_album(self, album_id: str, asset_ids: list[str]) -> list[dict]:
         """Add assets to an album and return the per-item results.
 

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -499,6 +499,59 @@ async def refresh_managed_album(
         return await _refresh_managed_album_unlocked(managed, all_accounts, store)
 
 
+async def _rename_managed_album_unlocked(
+    managed: ManagedAlbum,
+    owner_account: Account,
+    new_name: str,
+    store: ConfigStore,
+) -> list[SyncLogEntry]:
+    """Rename an Immich album and update its managed snapshot after success."""
+    previous_name = managed.album_name
+    client = ImmichClient(owner_account.immich_url, owner_account.api_key)
+    try:
+        await client.update_album(managed.album_id, {"albumName": new_name})
+    except AlbumNotFoundError:
+        return [SyncLogEntry(
+            id=str(uuid.uuid4()), timestamp=_now(), action="rename_album",
+            details=f"Album '{previous_name}' existiert nicht in Immich.",
+            status="error", error_message="ALBUM_DELETED",
+            message_key="log_album_not_found",
+            message_params={"album": previous_name},
+        )]
+    except Exception:
+        return [SyncLogEntry(
+            id=str(uuid.uuid4()), timestamp=_now(), action="rename_album",
+            details=f"Album '{previous_name}' konnte nicht umbenannt werden",
+            status="error", error_message="IMMICH_API_ERROR",
+            message_key="log_album_rename_failed",
+            message_params={"album": previous_name},
+        )]
+
+    managed.album_name = new_name
+    store.update_managed_album(managed)
+    return [SyncLogEntry(
+        id=str(uuid.uuid4()), timestamp=_now(), action="rename_album",
+        details=f"Album '{previous_name}' in '{new_name}' umbenannt",
+        status="success",
+        message_key="log_album_renamed",
+        message_params={"old_name": previous_name, "new_name": new_name},
+    )]
+
+
+async def rename_managed_album(
+    managed: ManagedAlbum,
+    owner_account: Account,
+    new_name: str,
+    store: ConfigStore,
+) -> list[SyncLogEntry]:
+    """Serialize renames with refreshes so stale snapshots cannot restore the old name."""
+    lock = _album_locks.setdefault(managed.id, asyncio.Lock())
+    async with lock:
+        return await _rename_managed_album_unlocked(
+            managed, owner_account, new_name, store
+        )
+
+
 async def extend_match(
     managed: ManagedAlbum,
     new_account: Account,

--- a/backend/tests/test_immich_client.py
+++ b/backend/tests/test_immich_client.py
@@ -132,6 +132,26 @@ async def test_name_sync_updates_a_person_with_put():
 
 
 @pytest.mark.asyncio
+async def test_album_rename_uses_patch_with_album_name():
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == "/api/albums/album-1"
+        assert json.loads(request.read()) == {"albumName": "New family name"}
+        return httpx.Response(
+            200,
+            json={"id": "album-1", "albumName": "New family name"},
+        )
+
+    client = ImmichClient(
+        "http://immich.test", "api-key", transport=httpx.MockTransport(handle)
+    )
+
+    album = await client.update_album("album-1", {"albumName": "New family name"})
+
+    assert album["albumName"] == "New family name"
+
+
+@pytest.mark.asyncio
 async def test_get_server_version_returns_the_parsed_payload():
     def handle(request: httpx.Request) -> httpx.Response:
         assert request.method == "GET"

--- a/backend/tests/test_sync_service.py
+++ b/backend/tests/test_sync_service.py
@@ -272,3 +272,43 @@ async def test_extend_match_adds_only_assets_missing_from_the_album(monkeypatch)
 
     assert add_calls == [["asset-2"]]
     assert managed.total_assets == 2
+
+
+@pytest.mark.asyncio
+async def test_rename_managed_album_updates_immich_and_persisted_name(monkeypatch):
+    updates: list[tuple[str, dict]] = []
+    persisted: list[ManagedAlbum] = []
+
+    class Client:
+        def __init__(self, *_):
+            pass
+
+        async def update_album(self, album_id, payload):
+            updates.append((album_id, payload))
+            return {"id": album_id, **payload}
+
+    class Store:
+        def update_managed_album(self, album):
+            persisted.append(album)
+
+    owner = account("owner")
+    managed = ManagedAlbum(
+        id="managed-1",
+        match_id="match-1",
+        album_id="album-1",
+        album_name="Old family name",
+        owner_account_id=owner.id,
+        person_refs=[],
+        created_at="2026-09-10T00:00:00+00:00",
+    )
+    monkeypatch.setattr(sync_service, "ImmichClient", Client)
+
+    logs = await sync_service.rename_managed_album(
+        managed, owner, "New family name", Store()
+    )
+
+    assert updates == [("album-1", {"albumName": "New family name"})]
+    assert managed.album_name == "New family name"
+    assert persisted == [managed]
+    assert logs[0].status == "success"
+    assert logs[0].message_key == "log_album_renamed"

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -217,3 +217,23 @@ describe("Fehler-Schluessel aus der Antwort", () => {
     }
   });
 });
+describe("managed album rename client", () => {
+  it("patches the managed album with the new name", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.sync.renameAlbum("managed-1", "New family name");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/sync/albums/managed-1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ album_name: "New family name" }),
+      })
+    );
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -252,6 +252,11 @@ export const api = {
     refreshAlbum: (managedAlbumId: string) =>
       request<SyncLogEntry[]>(`/sync/album/${managedAlbumId}/refresh`, { method: "POST" }),
     albums: () => request<ManagedAlbum[]>("/sync/albums"),
+    renameAlbum: (managedAlbumId: string, albumName: string) =>
+      request<SyncLogEntry[]>(`/sync/albums/${managedAlbumId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ album_name: albumName }),
+      }),
     deleteAlbum: (managedAlbumId: string) =>
       request<void>(`/sync/albums/${managedAlbumId}`, { method: "DELETE" }),
     undo: (logEntryId: string) =>

--- a/frontend/src/components/AlbumsOverview.tsx
+++ b/frontend/src/components/AlbumsOverview.tsx
@@ -1,8 +1,20 @@
 import React from "react";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
-import { Loader2, RefreshCw, Trash2, Disc, AlertTriangle, User, Clock, Timer } from "lucide-react";
+import {
+  Loader2,
+  RefreshCw,
+  Trash2,
+  Disc,
+  AlertTriangle,
+  User,
+  Clock,
+  Timer,
+  X,
+  Pencil,
+  Check,
+} from "lucide-react";
 import { api, ManagedAlbum, SyncLogEntry } from "../api/client";
-import { formatDate, LANG_LOCALES, useT } from "../i18n";
+import { formatDate, LANG_LOCALES, useT, type ServerErrorLike } from "../i18n";
 
 interface AlbumGroup {
   album_name: string;
@@ -90,11 +102,14 @@ function AlbumGroupCard({
   externalLogs?: SyncLogEntry[] | null; // results pushed from "Alle synchronisieren"
   externalSyncing?: boolean;
 }) {
-  const { t, lang } = useT();
+  const { t, lang, errorText } = useT();
   const qc = useQueryClient();
   const [localLogs, setLocalLogs] = React.useState<SyncLogEntry[] | null>(null);
   const [localSyncing, setLocalSyncing] = React.useState(false);
   const [deleting, setDeleting] = React.useState(false);
+  const [renaming, setRenaming] = React.useState(false);
+  const [renameValue, setRenameValue] = React.useState(group.album_name);
+  const [renameError, setRenameError] = React.useState<string | null>(null);
 
   // External (bulk) results take priority over local results
   const displayLogs = externalLogs !== undefined ? externalLogs : localLogs;
@@ -128,6 +143,33 @@ function AlbumGroupCard({
     qc.invalidateQueries({ queryKey: ["matches"] });
   };
 
+  const handleRename = async () => {
+    const nextName = renameValue.trim();
+    if (!nextName || nextName === group.album_name) {
+      setRenaming(false);
+      setRenameValue(group.album_name);
+      return;
+    }
+    setRenameError(null);
+    setLocalSyncing(true);
+    setLocalLogs(null);
+    const logs: SyncLogEntry[] = [];
+    try {
+      for (const album of group.albums) {
+        logs.push(...(await api.sync.renameAlbum(album.id, nextName)));
+      }
+      setLocalLogs(logs);
+      if (logs.every((entry) => entry.status === "success")) setRenaming(false);
+      qc.invalidateQueries({ queryKey: ["managed-albums"] });
+      qc.invalidateQueries({ queryKey: ["sync-log"] });
+      qc.invalidateQueries({ queryKey: ["matches"] });
+    } catch (error) {
+      setRenameError(errorText(error as ServerErrorLike));
+    } finally {
+      setLocalSyncing(false);
+    }
+  };
+
   const isDeleted = displayLogs?.some((e) => e.error_message === "ALBUM_DELETED");
 
   return (
@@ -136,7 +178,46 @@ function AlbumGroupCard({
         <div className="flex items-center gap-2">
           <Disc size={18} className={isDeleted ? "text-red-400" : "text-blue-400"} />
           <div>
-            <h3 className="font-semibold">{group.album_name}</h3>
+            {renaming ? (
+              <div className="flex items-center gap-1.5">
+                <input
+                  className="input py-1 text-sm"
+                  value={renameValue}
+                  onChange={(event) => setRenameValue(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") handleRename();
+                    if (event.key === "Escape") {
+                      setRenaming(false);
+                      setRenameValue(group.album_name);
+                    }
+                  }}
+                  aria-label={t("album_rename_action")}
+                  autoFocus
+                  disabled={localSyncing}
+                />
+                <button
+                  className="p-1 text-emerald-400 hover:text-emerald-300"
+                  onClick={handleRename}
+                  disabled={localSyncing || !renameValue.trim()}
+                  aria-label={t("save")}
+                >
+                  <Check size={15} />
+                </button>
+                <button
+                  className="p-1 text-gray-500 hover:text-gray-300"
+                  onClick={() => {
+                    setRenaming(false);
+                    setRenameValue(group.album_name);
+                    setRenameError(null);
+                  }}
+                  aria-label={t("cancel")}
+                >
+                  <X size={15} />
+                </button>
+              </div>
+            ) : (
+              <h3 className="font-semibold">{group.album_name}</h3>
+            )}
             <p className="text-xs text-gray-500">
               {t("owner")}: {group.owner_name}
             </p>
@@ -166,6 +247,7 @@ function AlbumGroupCard({
       </div>
 
       <SyncLogDisplay logs={displayLogs} syncing={syncing} />
+      {renameError && <p className="text-xs text-red-400">{renameError}</p>}
 
       {isDeleted && (
         <div className="flex items-center gap-2 text-xs text-amber-400 bg-amber-900/20 border border-amber-800 rounded px-3 py-2">
@@ -174,7 +256,19 @@ function AlbumGroupCard({
         </div>
       )}
 
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
+        <button
+          className="btn-ghost text-xs flex items-center gap-1.5"
+          onClick={() => {
+            setRenameValue(group.album_name);
+            setRenameError(null);
+            setRenaming(true);
+          }}
+          disabled={syncing || deleting || renaming}
+        >
+          <Pencil size={13} />
+          {t("album_rename_action")}
+        </button>
         <button
           className="btn-primary text-xs flex items-center gap-1.5"
           onClick={handleRefresh}

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -686,6 +686,12 @@ export const translations = {
         ? `¿Eliminar ${n} entradas del álbum "${name}"?\n\nEl álbum se conservará en Immich, pero dejará de sincronizarse.`
         : `¿Eliminar la entrada del álbum "${name}"?\n\nEl álbum se conservará en Immich, pero dejará de sincronizarse.`,
   },
+  album_rename_action: {
+    de: "Album umbenennen",
+    en: "Rename album",
+    "pt-BR": "Renomear álbum",
+    "es-ES": "Cambiar nombre del álbum",
+  },
 
   // ── SyncPanel ─────────────────────────────────────────────────────────
   log_subtitle: {
@@ -1260,6 +1266,18 @@ const logMessages: Record<string, Record<Lang, LogMessageFn>> = {
     en: (p) => `Album '${p.album}' could not be created`,
     "pt-BR": (p) => `Álbum '${p.album}' não pode ser criado`,
     "es-ES": (p) => `No se ha podido crear el álbum '${p.album}'`,
+  },
+  log_album_renamed: {
+    de: (p) => `Album '${p.old_name}' in '${p.new_name}' umbenannt`,
+    en: (p) => `Album '${p.old_name}' renamed to '${p.new_name}'`,
+    "pt-BR": (p) => `Álbum '${p.old_name}' renomeado para '${p.new_name}'`,
+    "es-ES": (p) => `Álbum '${p.old_name}' renombrado como '${p.new_name}'`,
+  },
+  log_album_rename_failed: {
+    de: (p) => `Album '${p.album}' konnte nicht umbenannt werden`,
+    en: (p) => `Album '${p.album}' could not be renamed`,
+    "pt-BR": (p) => `Não foi possível renomear o álbum '${p.album}'`,
+    "es-ES": (p) => `No se ha podido cambiar el nombre del álbum '${p.album}'`,
   },
   log_sync_failed: {
     de: (p) => `Sync von '${p.account}' fehlgeschlagen`,


### PR DESCRIPTION
 ## Summary

  Adds the ability to rename managed albums directly from Immich Family Tools.

  The album name is updated in Immich first and persisted locally only after the API confirms the change. When one card
  represents multiple grouped albums, each album is renamed through its owning account.

  ## Changes

  - Add inline album-name editing to the Albums overview
  - Support saving with Enter and cancelling with Escape
  - Rename albums through Immich's `PATCH /api/albums/{id}` endpoint
  - Update the corresponding managed-album records after success
  - Serialize renames with album refreshes to prevent stale data from restoring the previous name
  - Show localized success and error entries in the sync log
  - Add translations for German, English, Spanish, and Portuguese (Brazil)
  - Document the new capability in the README

  ## Required permission

  The Immich API key requires the existing `album.update` permission.